### PR TITLE
Bump rust from 1.84-bookworm to 1.88-bookworm in /docker/backend

Bumps rust from 1.84-bookworm to 1.88-bookworm.

---
updated-dependencies:
- dependency-name: rust
  dependency-version: 1.88-bookworm
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 ARG commitHash
 ENV MEMPOOL_COMMIT_HASH=${commitHash}
@@ -24,7 +24,7 @@ RUN npm install --omit=dev --omit=optional
 WORKDIR /build
 RUN npm run package
 
-FROM rust:1.84-bookworm AS runtime
+FROM rust:1.88-bookworm AS runtime
 
 RUN apt-get update && \
     apt-get install -y curl ca-certificates && \


### PR DESCRIPTION
<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->
