### PR TITLE
Bump nginx from 1.27.0-alpine to 1.29.0-alpine in /docker/frontend

Bumps nginx from 1.27.0-alpine to 1.29.0-alpine.

---
updated-dependencies:
- dependency-name: nginx
  dependency-version: 1.29.0-alpine
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install --omit=dev --omit=optional
 
 RUN npm run build
 
-FROM nginx:1.27.0-alpine
+FROM nginx:1.29.0-alpine
 
 WORKDIR /patch
 


### PR DESCRIPTION
<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->
